### PR TITLE
Do not clear ALL highlight groups before applying gruvbox colors

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -3,4 +3,4 @@ lua package.loaded["gruvbox"] = nil
 lua package.loaded["gruvbox.base"] = nil
 lua package.loaded["gruvbox.plugins.highlights"] = nil
 lua package.loaded["gruvbox.languages"] = nil
-lua require("lush")(require("gruvbox"))
+lua require("lush")(require("gruvbox"), {force_clear = false})


### PR DESCRIPTION
`lush` clears all defined highlight groups by default when applying, so any unknown to `gruvbox.nvim` plugins loaded after it will loose all their groups. Let's keep unknown highlight groups untouched - they probably have reasonable defaults.