### PR TITLE
Fix delimiters color

### DIFF
--- a/lua/gruvbox/base.lua
+++ b/lua/gruvbox/base.lua
@@ -249,7 +249,7 @@ local base_group = lush(function()
     Typedef {GruvboxYellow},
     SpecialChar {GruvboxRed},
     Tag {GruvboxAquaBold},
-    Delimiter {GruvboxGray},
+    Delimiter {GruvboxFg3},
     Comment {fg = gray, gui = styles.italic_comments},
     Debug {GruvboxRed},
     Underlined {fg = blue, gui = styles.underline},


### PR DESCRIPTION
Fix #80
Making delimiters gray wasn't a good idea