### PR TITLE
fix: clear TSError highlight

### DIFF
--- a/lua/gruvbox/plugins/highlights.lua
+++ b/lua/gruvbox/plugins/highlights.lua
@@ -18,7 +18,7 @@ local plugins = lush(function()
 		netrwVersion({ base.GruvboxGreen }),
 		-- nvim-treesitter
 		TSNone({}),
-		TSError({ base.Error }),
+		TSError({ }),
 		TSTitle({ base.Title }),
 		TSLiteral({ base.String }),
 		TSURI({ base.Underlined }),


### PR DESCRIPTION
This PR aims to properly solve the issue raised here: https://github.com/ellisonleao/gruvbox.nvim/pull/90

Searching through `nvim-treesitter` and reading the [docs](https://github.com/nvim-treesitter/nvim-treesitter/blob/d2174f1d29086b51124d084f9402c5f9731f21bd/doc/nvim-treesitter.txt#L510-L512) it's clear that it's recommended to not set `TSError` or set it to `Normal`.

Showing syntax and parser errors is rarely wanted, which is clearly proved by https://github.com/ellisonleao/gruvbox.nvim/pull/90.

Ref: https://github.com/nvim-treesitter/nvim-treesitter/pull/1628