### PR TITLE
add support for vim.g.gruvbox_cursor_line

### DIFF
--- a/lua/gruvbox/base.lua
+++ b/lua/gruvbox/base.lua
@@ -85,6 +85,7 @@ local color_column = utils.get_color_from_var(vim.g.gruvbox_color_column, bg1, c
 local vert_split = utils.get_color_from_var(vim.g.gruvbox_vert_split, bg0, colors)
 local tabline_sel = utils.get_color_from_var(vim.g.gruvbox_tabline_sel, green, colors)
 local sign_column = utils.get_color_from_var(vim.g.gruvbox_sign_column, bg1, colors)
+local cursor_line = utils.get_color_from_var(vim.g.gruvbox_cursor_line, bg1, colors)
 
 local improved_strings_fg = fg1
 local improved_strings_bg = bg1
@@ -175,7 +176,7 @@ local base_group = {
   iCursor = "Cursor",
   vCursor = "Cursor",
   CursorIM = "Cursor",
-  CursorLine = { bg = bg1 },
+  CursorLine = { bg = cursor_line },
   CursorColumn = "CursorLine",
   Directory = "GruvboxGreenBold",
   DiffAdd = { fg = green, bg = bg0, gui = styles.inverse },


### PR DESCRIPTION
There is already a bunch of possible configuration for other kind of color like `vim.g.gruvbox_sign_column` and `vim.g.gruvbox_number_column`.
This PR brings the same feature for the CursorLine to be able to create an homogeneous theme variation.