### PR TITLE
Fix quickfix search highlighting

### DIFF
--- a/lua/gruvbox/base.lua
+++ b/lua/gruvbox/base.lua
@@ -201,7 +201,7 @@ local base_group = {
   PmenuSbar = { bg = bg2 },
   PmenuThumb = { bg = bg4 },
   Question = "GruvboxOrangeBold",
-  QuickFixLine = { fg = bg0, bg = yellow, gui = styles.bold },
+  QuickFixLine = { bg = bg0, gui = styles.bold },
   Search = { fg = hls_highlight, bg = bg0, gui = styles.inverse },
   SpecialKey = "GruvboxFg4",
   SpellRare = "GruvboxPurpleUnderline",


### PR DESCRIPTION
Hi @ellisonleao, thanks for your excellent port of my favorite colorscheme!

I noticed a minor annoyance and thought I'd open a PR. Essentially what happens when you do a project wide search (with ripgrep or whatever), I prefer only the search term to be highlighted (expected behavior). This does not happen currently.

Take a look at the before/after for a clearer example.

Before:
![before](https://user-images.githubusercontent.com/3199183/153128445-98ed3eac-cd97-4ea7-83ba-f3cc73cf1c79.png)

After:
![after](https://user-images.githubusercontent.com/3199183/153128460-ef2b508b-3185-4f4b-ad6a-03075d0a5e69.png)
