### PR TITLE
Tweak sign column color to match background

### DIFF
--- a/lua/gruvbox/base.lua
+++ b/lua/gruvbox/base.lua
@@ -84,7 +84,7 @@ local number_column = utils.get_color_from_var(vim.g.gruvbox_number_column, nil,
 local color_column = utils.get_color_from_var(vim.g.gruvbox_color_column, bg1, colors)
 local vert_split = utils.get_color_from_var(vim.g.gruvbox_vert_split, bg0, colors)
 local tabline_sel = utils.get_color_from_var(vim.g.gruvbox_tabline_sel, green, colors)
-local sign_column = utils.get_color_from_var(vim.g.gruvbox_sign_column, bg1, colors)
+local sign_column = utils.get_color_from_var(vim.g.gruvbox_sign_column, bg0, colors)
 local cursor_line = utils.get_color_from_var(vim.g.gruvbox_cursor_line, bg1, colors)
 
 local improved_strings_fg = fg1


### PR DESCRIPTION
This pull request changes the sign column highlighting color to match the background color. As it stands right now, the color of the sign column appears to be much lighter than it seems like it should be (i.e. the color matches the current line selection). This doesn't seem to be intended since it makes the theme less smooth to the eyes when the sign column is enabled.

The sign column can be shown using `:set scl=yes` and to it hide the `:set scl=no` can be used.