### PR TITLE
fix: add cursearch highlight

### DIFF
--- a/lua/gruvbox/base.lua
+++ b/lua/gruvbox/base.lua
@@ -230,6 +230,7 @@ local base_group = {
   Question = { link = "GruvboxOrangeBold" },
   QuickFixLine = { bg = bg0, bold = vim.g.gruvbox_bold },
   Search = { fg = hls_highlight, bg = bg0, reverse = vim.g.gruvbox_inverse },
+  CurSearch = { link = "IncSearch" },
   SpecialKey = { link = "GruvboxFg4" },
   SpellRare = { link = "GruvboxPurpleUnderline" },
   SpellBad = { link = "GruvboxRedUnderline" },


### PR DESCRIPTION
This PR links the new `CurSearch` highlight with the `IncSearch` highlight. This gives a consistent highlight of the first and current search.

See https://github.com/neovim/neovim/pull/18081 for more details.