### PR TITLE
Add palette overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,24 @@ require("gruvbox").setup({
 vim.cmd("colorscheme gruvbox")
 ```
 
-## Overriding Highlight groups
+## Overriding
+
+###  Pallette
+
+You can specify your own palette colors. For example:
+
+```lua
+require("gruvbox").setup({
+    palette_overrides = {
+        bright_green = "#990000",
+    }
+})
+vim.cmd("colorscheme gruvbox")
+```
+
+More colors in the [palette.lua](lua/gruvbox/palette.lua) file
+
+###  Highlight groups
 
 If you don't enjoy the current color for a specific highlight group, now you can just override it in the setup. For
 example:

--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -93,9 +93,11 @@ end
 
 groups.setup = function()
   local config = require("gruvbox").config
-  local palette = require("gruvbox.palette")
-  local colors = get_base_colors(palette, config.contrast)
 
+  local palette = require("gruvbox.palette")
+  for k,v in pairs(config.palette_overrides) do palette[k] = v end
+
+  local colors = get_base_colors(palette, config.contrast)
   set_terminal_colors(colors)
 
   local groups = {

--- a/lua/gruvbox/init.lua
+++ b/lua/gruvbox/init.lua
@@ -13,6 +13,7 @@ M.config = {
   invert_intend_guides = false,
   inverse = true, -- invert background for search, diffs, statuslines and errors
   contrast = "", -- can be "hard", "soft" or empty string
+  palette_overrides = {},
   overrides = {},
 }
 

--- a/tests/gruvbox/gruvbox_spec.lua
+++ b/tests/gruvbox/gruvbox_spec.lua
@@ -15,6 +15,7 @@ describe("setup", function()
       invert_tabline = false,
       invert_intend_guides = false,
       contrast = "",
+      palette_overrides = {},
       overrides = {},
     }
 
@@ -35,6 +36,7 @@ describe("setup", function()
       invert_tabline = false,
       invert_intend_guides = false,
       contrast = "",
+      palette_overrides = {},
       overrides = {},
     }
 
@@ -102,6 +104,23 @@ describe("highlight overrides", function()
     local config = {
       overrides = {
         Function = { bg = "#990000" },
+      },
+    }
+
+    gruvbox.setup(config)
+    gruvbox.load()
+
+    local group_id = vim.api.nvim_get_hl_id_by_name("Function")
+    local values = {
+      background = vim.fn.synIDattr(group_id, "bg", "gui"),
+    }
+    assert.are.same(values, { background = "#990000" })
+  end)
+
+  it("should override palette", function()
+    local config = {
+      palette_overrides = {
+        bright_green = "#990000",
       },
     }
 


### PR DESCRIPTION
Added `palette_overrides` config key:

```lua
require("gruvbox").setup({
    palette_overrides = {
        bright_green = "#990000",
    }
})
vim.cmd("colorscheme gruvbox")
```