### PR TITLE
feat: config override colors support palette variables

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -740,6 +740,11 @@ groups.setup = function()
     if groups[group] and not vim.tbl_isempty(hl) then
       groups[group].link = nil
     end
+    for color_key, color in pairs(hl) do
+      if color:match("^[^#]") then
+        hl[color_key] = palette[color]
+      end
+    end
     groups[group] = vim.tbl_extend("force", groups[group] or {}, hl)
   end
 

--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -741,7 +741,7 @@ groups.setup = function()
       groups[group].link = nil
     end
     for color_key, color in pairs(hl) do
-      if color:match("^[^#]") then
+      if color:match("^%a") then
         hl[color_key] = palette[color]
       end
     end


### PR DESCRIPTION
allows you to do this: (still supports hex but adds this as quality of life improvement)
``` lua
require("gruvbox").setup({
  overrides = {
	  SignColumn = {bg = "dark0"}, -- use palette variables instead of hex
	  EndOfBuffer = {fg = "dark0"},
	  MsgArea = {fg = "dark3"}
  },
})
```