### PR TITLE
Add treesitter highlight groups for diff

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -309,6 +309,8 @@ groups.setup = function()
     ["@text.note"] = { link = "SpecialComment" },
     ["@text.warning"] = { link = "WarningMsg" },
     ["@text.danger"] = { link = "ErrorMsg" },
+    ["@text.diff.add"] = { link = "diffAdded" },
+    ["@text.diff.delete"] = { link = "diffRemoved" },
     ["@tag"] = { link = "Tag" },
     ["@tag.attribute"] = { link = "Identifier" },
     ["@tag.delimiter"] = { link = "Delimiter" },


### PR DESCRIPTION
Diff files are currently missing highlighting.
See https://github.com/nvim-treesitter/nvim-treesitter/commit/1e4b23c26678bd36e3da638183996eaa30e7fba8.