### PR TITLE
Remove italics from Operator

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -192,7 +192,7 @@ groups.setup = function()
     Repeat = { link = "GruvboxRed" },
     Label = { link = "GruvboxRed" },
     Exception = { link = "GruvboxRed" },
-    Operator = { fg = colors.orange, italic = config.italic },
+    Operator = { link = "GruvboxOrange" },
     Keyword = { link = "GruvboxRed" },
     Identifier = { link = "GruvboxBlue" },
     Function = { link = "GruvboxGreenBold" },


### PR DESCRIPTION
This makes operators like `|` and `!` look like `/`.