### PR TITLE
Add missing highlight group for coc.nvim

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -402,6 +402,7 @@ groups.setup = function()
     CocDiagnosticsInfo = { link = "GruvboxBlue" },
     CocDiagnosticsHint = { link = "GruvboxAqua" },
     CocSelectedText = { link = "GruvboxRed" },
+    CocMenuSel = { link = "PmenuSel" },
     CocCodeLens = { link = "GruvboxGray" },
     CocErrorHighlight = { link = "GruvboxRedUnderline" },
     CocWarningHighlight = { link = "GruvboxOrangeUnderline" },


### PR DESCRIPTION
Add missing `CocMenuSel` group for coc.nvim, without this the completion menu had no colors. I chose `PmenuSel` because it seems appropriate, feel free to edit if there's a better match