### PR TITLE
fix: add cursearch highlight

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -160,6 +160,7 @@ groups.setup = function()
     VisualNOS = { link = "Visual" },
     Search = { fg = colors.yellow, bg = colors.bg0, reverse = config.inverse },
     IncSearch = { fg = colors.orange, bg = colors.bg0, reverse = config.inverse },
+    CurSearch = { link = "IncSeach" },
     QuickFixLine = { fg = colors.bg0, bg = colors.yellow, bold = config.bold },
     Underlined = { fg = colors.blue, underline = config.underline },
     StatusLine = { fg = colors.bg2, bg = colors.fg1, reverse = config.inverse },


### PR DESCRIPTION
The `CurSearch` highlight has for some reason been removed.

See https://github.com/ellisonleao/gruvbox.nvim/pull/114 for further information.