### PR TITLE
fix: make directories gruvboxblue

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -169,7 +169,7 @@ groups.setup = function()
     WinBarNC = { fg = colors.fg3, bg = colors.bg1 },
     VertSplit = { fg = colors.bg3, bg = colors.bg0 },
     WildMenu = { fg = colors.blue, bg = colors.bg2, bold = config.bold },
-    Directory = { link = "GruvboxGreenBold" },
+    Directory = { link = "GruvboxBlueBold" },
     Title = { link = "GruvboxGreenBold" },
     ErrorMsg = { fg = colors.bg0, bg = colors.red, bold = config.bold },
     MoreMsg = { link = "GruvboxYellowBold" },


### PR DESCRIPTION
I think has a lot more sense making `Directory` gruvboxblue since is by default the colors of the directories in the terminal. Also I think we are using gruvboxblue for NvimTree directories too.

<img width="431" alt="Screenshot 2022-12-12 at 16 35 54" src="https://user-images.githubusercontent.com/96259932/207086703-bccc9f43-eab2-422d-aeaa-8a44b8744998.png">
