### PR TITLE
Update background color of INC Search

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -159,7 +159,7 @@ groups.setup = function()
     Visual = { bg = colors.bg3, reverse = config.invert_selection },
     VisualNOS = { link = "Visual" },
     Search = { fg = colors.yellow, bg = colors.bg0, reverse = config.inverse },
-    IncSearch = { fg = colors.orange, bg = colors.bg0, reverse = config.inverse },
+    IncSearch = { fg = colors.yellow, bg = colors.bg0, reverse = config.inverse },
     CurSearch = { link = "IncSearch" },
     QuickFixLine = { fg = colors.bg0, bg = colors.yellow, bold = config.bold },
     Underlined = { fg = colors.blue, underline = config.underline },


### PR DESCRIPTION
Having fg = orange for IncSearch would give the illusion to the user that the cursor is hidden(since its color is also orange). So, this distracts that user as it would seem that cursor is not moving on J/K.
Setting fg = yellow for IncSearch so that users can differentiate between highlight and cursor.