### PR TITLE
fix: change @namespace and add @annotation highlight

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -252,6 +252,7 @@ groups.setup = function()
     LspCodeLens = { link = "GruvboxGray" },
     -- nvim-treesitter (0.8 compat)
     -- Adapted from https://github.com/nvim-treesitter/nvim-treesitter/commit/42ab95d5e11f247c6f0c8f5181b02e816caa4a4f#commitcomment-87014462
+    ["@annotation"] = { link = "Operator" },
     ["@comment"] = { link = "Comment" },
     ["@none"] = { bg = "NONE", fg = "NONE" },
     ["@preproc"] = { link = "PreProc" },
@@ -299,7 +300,7 @@ groups.setup = function()
     ["@constant"] = { link = "Constant" },
     ["@constant.builtin"] = { link = "Special" },
     ["@constant.macro"] = { link = "Define" },
-    ["@namespace"] = { link = "Include" },
+    ["@namespace"] = { link = "GruvboxFg1" },
     ["@symbol"] = { link = "Identifier" },
     ["@text"] = { link = "GruvboxFg1" },
     ["@text.title"] = { link = "Title" },


### PR DESCRIPTION
I am running Neovim with [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls) for LSP support in my Java development. When I have the LSP client attached, I noticed the imports statement syntax highlighting looked off.

See screenshot below (Left is `@namespace Include` and Right is `@namespace GruvboxFg1`)
![Screenshot 2022-12-26 at 12 12 36 AM](https://user-images.githubusercontent.com/10135646/209504338-fb09b157-a0f8-4a9c-92d9-9ba431f44a84.png)


I sampled a couple colorschemes: everforest, github_dark, and rosepine. It seems like `@namespace` is normally mapped to the same highlight as `@variable` or `@variable.builtin`. I just personally liked the look of `@variable` more so I mapped it to `GruvboxFg1`. For annotation I mapped it to Operator so it would have the same coloring as the @ symbol.

'@namespace' and '@annotation' appear to be coming from the language server: https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java

Please let me know if you need any additional info. Enjoying the coloscheme in Lua 🙂