### PR TITLE
Add `terminal` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ require("gruvbox").setup({
   overrides = {},
   dim_inactive = false,
   transparent_mode = false,
+  terminal = true, -- enable/disable setting colors for the builtin terminal
 })
 vim.cmd("colorscheme gruvbox")
 ```

--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -100,7 +100,9 @@ groups.setup = function()
   end
 
   local colors = get_base_colors(palette, config.contrast)
-  set_terminal_colors(colors)
+  if config.terminal then
+    set_terminal_colors(colors)
+  end
 
   local groups = {
     -- Base groups

--- a/lua/gruvbox/init.lua
+++ b/lua/gruvbox/init.lua
@@ -17,6 +17,7 @@ M.config = {
   overrides = {},
   dim_inactive = false,
   transparent_mode = false,
+  terminal = true,
 }
 
 function M.setup(config)

--- a/tests/gruvbox/gruvbox_spec.lua
+++ b/tests/gruvbox/gruvbox_spec.lua
@@ -19,6 +19,7 @@ describe("setup", function()
       overrides = {},
       dim_inactive = false,
       transparent_mode = false,
+      terminal = true,
     }
 
     gruvbox.setup()
@@ -42,6 +43,7 @@ describe("setup", function()
       overrides = {},
       dim_inactive = false,
       transparent_mode = false,
+      terminal = true
     }
 
     gruvbox.setup({ undercurl = false, underline = false })


### PR DESCRIPTION
This new option enables/disables setting the color palette of the builtin terminal to the gruvbox color palette. The `terminal` option is by default `true`.