### PR TITLE
Fix nvim version check (0.7+ -> 0.8+)

### DIFF
--- a/lua/gruvbox/init.lua
+++ b/lua/gruvbox/init.lua
@@ -24,8 +24,8 @@ function M.setup(config)
 end
 
 M.load = function()
-  if vim.version().minor < 7 then
-    vim.notify_once("gruvbox.nvim: you must use neovim 0.7 or higher")
+  if vim.version().minor < 8 then
+    vim.notify_once("gruvbox.nvim: you must use neovim 0.8 or higher")
     return
   end
 


### PR DESCRIPTION
As of #163, NVIM's minimum required version was upgraded to 0.8. However, the related check at runtime was never updated. This PR has Gruvbox check the correct minimum required version of NVIM.