### PR TITLE
fix transparent background on window seperator

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -98,7 +98,7 @@ M.setup = function()
     StatusLineNC = { fg = colors.bg1, bg = colors.fg4, reverse = config.inverse },
     WinBar = { fg = colors.fg4, bg = colors.bg0 },
     WinBarNC = { fg = colors.fg3, bg = colors.bg1 },
-    VertSplit = config.transparent_mode and { fg = colors.bg3, bg = nil } or { fg = colors.bg3, bg = colors.bg0 },
+    WinSeparator = config.transparent_mode and { fg = colors.bg3, bg = nil } or { fg = colors.bg3, bg = colors.bg0 },
     WildMenu = { fg = colors.blue, bg = colors.bg2, bold = config.bold },
     Directory = { link = "GruvboxBlueBold" },
     Title = { link = "GruvboxGreenBold" },

--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -98,7 +98,7 @@ M.setup = function()
     StatusLineNC = { fg = colors.bg1, bg = colors.fg4, reverse = config.inverse },
     WinBar = { fg = colors.fg4, bg = colors.bg0 },
     WinBarNC = { fg = colors.fg3, bg = colors.bg1 },
-    VertSplit = { fg = colors.bg3, bg = colors.bg0 },
+    VertSplit = config.transparent_mode and { fg = colors.bg3, bg = nil } or { fg = colors.bg3, bg = colors.bg0 },
     WildMenu = { fg = colors.blue, bg = colors.bg2, bold = config.bold },
     Directory = { link = "GruvboxBlueBold" },
     Title = { link = "GruvboxGreenBold" },


### PR DESCRIPTION
The split used to show the background color (left side).
![screenshot_20230221_00-30-53](https://user-images.githubusercontent.com/12686819/220212851-f5cf5736-bf6e-4862-a400-f2674dfd6616.png)

Also changed `VertSplit` (deprecated) to `WinSeparator`.