### PR TITLE
feat: add `NoiceCursor` highlight group

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -782,6 +782,8 @@ M.setup = function()
     CarbonIndicator = { link = "GruvboxGray" },
     CarbonDanger = { link = "GruvboxRed" },
     CarbonPending = { link = "GruvboxYellow" },
+    -- noice.nvim
+    NoiceCursor = { link = "TermCursor" },
   }
 
   for group, hl in pairs(config.overrides) do


### PR DESCRIPTION
This PR adds NoiceCursor highlight group, fixes noice's cmdline cursor.

<details>

<summary>Old description</summary>

For some reason, `Cursor` reverse is set to `config.inverse` value.

If I change `config.inverse` cursor stays the same.

| `reverse` = true | `reverse` = false |
| ---------------- | ----------------- |
| ![rtrue]         | ![rfalse]         |
| ![rtrue2]        | ![rfalse2]        |

[rtrue]: https://i.imgur.com/sPVqwxd.png
[rtrue2]: https://i.imgur.com/iTPIIo8.png
[rfalse]: https://i.imgur.com/ITY7vfQ.png
[rfalse2]: https://i.imgur.com/d0k0iIP.png

**But**, if reverse is false, noice.nvim cmdline cursor breaks.

| `reverse` = true | `reverse` = false |
| ---------------- | ----------------- |
| ![ntrue]         | ![nfalse]         |

[nfalse]: https://i.imgur.com/jq0bGZr.png
[ntrue]: https://i.imgur.com/P17XFgm.png

</details>