### PR TITLE
add `on_highlight` function to config

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -791,6 +791,8 @@ M.setup = function()
     groups[group] = vim.tbl_extend("force", groups[group] or {}, hl)
   end
 
+  config.on_highlight(groups, colors)
+
   return groups
 end
 

--- a/lua/gruvbox/init.lua
+++ b/lua/gruvbox/init.lua
@@ -17,6 +17,7 @@ M.config = {
   overrides = {},
   dim_inactive = false,
   transparent_mode = false,
+  on_highlight = function(groups, colors) end,
 }
 
 function M.setup(config)


### PR DESCRIPTION
This is for a more fine-grained control over the highlighting, with minimal changes to the code-base, and does not break any existing configuration. It is used when the user wants to create/modify some highlight groups, but want to access the colors of the gruvbox palette (created in `groups.lua` line 25).

An example configuration will be 
```lua
require("gruvbox").setup {
  overrides = {
    String = { link = "GruvboxGreen" },
    Operator = { link = "GruvboxOrange" },
    ["@namespace.latex"] = { link = "GruvboxYellowBold" },
  },
  palette_overrides = {
    bright_green = "#b0b846",
  },
  on_highlight = function(groups, colors)
    groups["@text.title.latex"] = { fg = colors.light0_hard, bold = true }
  end,
}
```