### PR TITLE
fixing override logic

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -787,16 +787,12 @@ M.setup = function()
   }
 
   for group, hl in pairs(config.overrides) do
-    -- When `link` is set together with other attrs, only `link` will take effect.
-    -- e.g. `{ link = "GruvboxRed", fg = colors.blue }` The final color is red.
-    -- Dereference the `link` and let user overrides it's attr.
-    local link = nil
-    if groups[group] and not vim.tbl_isempty(hl) then
-      link = groups[group]["link"]
-      groups[group]["link"] = nil
+    if groups[group] then
+      -- "link" should not mix with other configs (:h hi-link)
+      groups[group].link = nil
     end
 
-    groups[group] = vim.tbl_extend("force", groups[group] or {}, groups[link] or {}, hl)
+    groups[group] = vim.tbl_extend("force", groups[group] or {}, hl)
   end
 
   return groups

--- a/lua/gruvbox/palette.lua
+++ b/lua/gruvbox/palette.lua
@@ -52,8 +52,8 @@ M.get_base_colors = function(bg, contrast)
   local config = require("gruvbox").config
   local p = M.colors
 
-  for k, v in pairs(config.palette_overrides) do
-    p[k] = v
+  for color, hex in pairs(config.palette_overrides) do
+    p[color] = hex
   end
 
   if bg == nil then

--- a/tests/gruvbox/gruvbox_spec.lua
+++ b/tests/gruvbox/gruvbox_spec.lua
@@ -123,34 +123,37 @@ describe("highlight overrides", function()
   it("should override links", function()
     local config = {
       overrides = {
-        Function = { bg = "#990000" },
+        TelescopePreviewBorder = { fg = "#990000", bg = nil },
       },
     }
-
     gruvbox.setup(config)
     gruvbox.load()
 
-    local group_id = vim.api.nvim_get_hl_id_by_name("Function")
+    local group_id = vim.api.nvim_get_hl_id_by_name("TelescopePreviewBorder")
     local values = {
-      background = vim.fn.synIDattr(group_id, "bg", "gui"),
+      fg = vim.fn.synIDattr(group_id, "fg", "gui"),
     }
-    assert.are.same(values, { background = "#990000" })
+
+    local expected = {
+      fg = "#990000",
+    }
+    assert.are.same(expected, values)
   end)
 
   it("should override palette", function()
     local config = {
       palette_overrides = {
-        bright_green = "#990000",
+        gray = "#ff9900",
       },
     }
 
     gruvbox.setup(config)
     gruvbox.load()
 
-    local group_id = vim.api.nvim_get_hl_id_by_name("Function")
+    local group_id = vim.api.nvim_get_hl_id_by_name("Comment")
     local values = {
-      background = vim.fn.synIDattr(group_id, "bg", "gui"),
+      fg = vim.fn.synIDattr(group_id, "fg", "gui"),
     }
-    assert.are.same(values, { background = "#990000" })
+    assert.are.same(values, { fg = "#ff9900" })
   end)
 end)


### PR DESCRIPTION
Another attempt to fix the override logic. Seems like `link` and other configs should **not** live together. This PR is rolling back the old logic to simplify things

Ref #223
Reverting #207