### PR TITLE
Add transparency to floats

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -75,6 +75,7 @@ M.setup = function()
     GruvboxAquaUnderline = { undercurl = config.undercurl, sp = colors.aqua },
     GruvboxOrangeUnderline = { undercurl = config.undercurl, sp = colors.orange },
     Normal = config.transparent_mode and { fg = colors.fg1, bg = nil } or { fg = colors.fg1, bg = colors.bg0 },
+    NormalFloat = config.transparent_mode and { fg = colors.fg1, bg = nil } or { fg = colors.fg1, bg = colors.bg0 },
     NormalNC = config.dim_inactive and { fg = colors.fg0, bg = colors.bg1 } or { link = "Normal" },
     CursorLine = { bg = colors.bg1 },
     CursorColumn = { link = "CursorLine" },


### PR DESCRIPTION
With transparency set to `true` and without this group floats like Lazy, Mason, NvTerm etc look pretty ugly
![image](https://user-images.githubusercontent.com/90396571/228343686-b01a5f21-3b7b-4ba0-b1e0-933164fb3229.png)
![image](https://user-images.githubusercontent.com/90396571/228343751-09e3b097-ce21-40b7-8d9c-5f2411c219d6.png)
![image](https://user-images.githubusercontent.com/90396571/228343790-5dd54485-8b58-4df0-878c-d0bf7b858116.png)

And with it:
![image](https://user-images.githubusercontent.com/90396571/228344585-ad1aecd7-7896-4c46-b8ef-6dc5138510f9.png)

