### PR TITLE
fix: add highlight for active parameter in signature help

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -183,6 +183,7 @@ M.setup = function()
     LspReferenceText = { link = "GruvboxYellowBold" },
     LspReferenceWrite = { link = "GruvboxOrangeBold" },
     LspCodeLens = { link = "GruvboxGray" },
+    LspSignatureActiveParameter = { fg = colors.bright_orange, bold = true },
     -- nvim-treesitter (0.8 compat)
     -- Adapted from https://github.com/nvim-treesitter/nvim-treesitter/commit/42ab95d5e11f247c6f0c8f5181b02e816caa4a4f#commitcomment-87014462
     ["@annotation"] = { link = "Operator" },


### PR DESCRIPTION
See https://github.com/neovim/neovim/pull/15018 for more information.