### PR TITLE
fix: LspSignatureActiveParameter color

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -183,7 +183,7 @@ M.setup = function()
     LspReferenceText = { link = "GruvboxYellowBold" },
     LspReferenceWrite = { link = "GruvboxOrangeBold" },
     LspCodeLens = { link = "GruvboxGray" },
-    LspSignatureActiveParameter = { fg = colors.bg0, bg = colors.yellow },
+    LspSignatureActiveParameter = { link = "Search" },
     -- semantic token
     -- adapted from https://github.com/jdrouhard/neovim/blob/9f035559defd9d575f37fd825954610065d9cf96/src/nvim/highlight_group.c#L267
     ["@class"] = { link = "@constructor" },

--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -183,7 +183,7 @@ M.setup = function()
     LspReferenceText = { link = "GruvboxYellowBold" },
     LspReferenceWrite = { link = "GruvboxOrangeBold" },
     LspCodeLens = { link = "GruvboxGray" },
-    LspSignatureActiveParameter = { fg = colors.bright_orange, bold = true },
+    LspSignatureActiveParameter = { fg = colors.orange, bold = true },
     -- semantic token
     -- adapted from https://github.com/jdrouhard/neovim/blob/9f035559defd9d575f37fd825954610065d9cf96/src/nvim/highlight_group.c#L267
     ["@class"] = { link = "@constructor" },

--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -183,7 +183,7 @@ M.setup = function()
     LspReferenceText = { link = "GruvboxYellowBold" },
     LspReferenceWrite = { link = "GruvboxOrangeBold" },
     LspCodeLens = { link = "GruvboxGray" },
-    LspSignatureActiveParameter = { fg = colors.orange, bold = true },
+    LspSignatureActiveParameter = { fg = colors.bg0, bg = colors.yellow },
     -- semantic token
     -- adapted from https://github.com/jdrouhard/neovim/blob/9f035559defd9d575f37fd825954610065d9cf96/src/nvim/highlight_group.c#L267
     ["@class"] = { link = "@constructor" },


### PR DESCRIPTION
`bright_orange` should be `orange` when calling `colors` from `require("gruvbox.palette").get_base_colors(vim.o.background, config.contrast)`
fix #231