### PR TITLE
remove treesitter-error highlight link

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -194,8 +194,6 @@ M.setup = function()
     -- @comment               ; line and block comments
     ["@comment"] = { link = "Comment" },
     -- @comment.documentation ; comments documenting code
-    -- @error                 ; syntax/parser errors
-    ["@error"] = { link = "Error" },
     -- @none                  ; completely disable the highlight
     ["@none"] = { bg = "NONE", fg = "NONE" },
     -- @preproc               ; various preprocessor directives & shebangs


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58657914/232536467-0d30b4a9-6b4c-4311-ae24-3cb336be83c7.png)

`Error` would inverse the color. That cause text with treesitter-error unreadable.