### PR TITLE
Proposal: make LspSemanticHighlight more consistent with Treesitter

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -408,19 +408,19 @@ M.setup = function()
 
     -- Semantic token
     -- See `:help lsp-semantic-highlight`
-    ["@lsp.type.class"] = { link = "@constructor" },
+    ["@lsp.type.class"] = { link = "@type" },
     ["@lsp.type.comment"] = {}, -- do not overwrite comments
-    ["@lsp.type.decorator"] = { link = "@parameter" },
+    ["@lsp.type.decorator"] = { link = "@macro" },
     ["@lsp.type.enum"] = { link = "@type" },
     ["@lsp.type.enumMember"] = { link = "@constant" },
     ["@lsp.type.function"] = { link = "@function" },
-    ["@lsp.type.interface"] = { link = "@keyword" },
+    ["@lsp.type.interface"] = { link = "@constructor" },
     ["@lsp.type.macro"] = { link = "@macro" },
     ["@lsp.type.method"] = { link = "@method" },
     ["@lsp.type.namespace"] = { link = "@namespace" },
     ["@lsp.type.parameter"] = { link = "@parameter" },
     ["@lsp.type.property"] = { link = "@property" },
-    ["@lsp.type.struct"] = { link = "@constructor" },
+    ["@lsp.type.struct"] = { link = "@type" },
     ["@lsp.type.type"] = { link = "@type" },
     ["@lsp.type.typeParameter"] = { link = "@type.definition" },
     ["@lsp.type.variable"] = { link = "@variable" },


### PR DESCRIPTION
After last update of neovim + gruvbox, LSP sends document highlights once ready. While this is a great feature, it's a bit annoying with gruvbox, because color-groups are not consistent, which causes a lot changes in the colors, once LSP is loaded (after a few seconds). Furthermore, colors are a bit strange now (see https://github.com/ellisonleao/gruvbox.nvim/issues/237).

With the few changes in this PR, the behaviour is slightly improved IMO, at least in C++ and Rust: colors change less between LSP and treesitter, and feel more logical.
 
Details:
 - @lsp.type.struct and @lsp.type.class are redirected to @type. Things reported as struct and class by LSP are "type" in Treesitter ( in C++ and Rust at least) so this removes a lot of color changes. And binding them to @constructor (redirected to GruvBoxOrange) isn't very pretty. I don't think having a different color for 'u32' and 'Hashmap'/'uint32_t' and 'std::unordered_map' adds value.
 - @lsp.type.decorator is redirected to @macro. This is consistent with Treesitter for Rust #derive macros. And I think it's better they have a different color from "parameters", which is already used a lot.
  - lsp.type.interface is redirected to @constructor. This is arbirtrary. I don't like them to be redirected to "keyword": I like when actual language keywords have a dedicated color (here red). I chose "constructor" because it redirects to GruvboxOrange which is not far from the Yellow one used for types.
  
 Screenshots:
  -  Rust
  

Treesitter only:
<img src="https://user-images.githubusercontent.com/44399944/235346233-485d9782-add0-4066-97a4-169d4bc430aa.png" alt="drawing" width="500"/>

Current:
<img src="https://user-images.githubusercontent.com/44399944/235346393-bc12dafe-edd4-4fed-9f79-9f994863112b.png" alt="drawing" width="500"/>


Proposal:
<img src="https://user-images.githubusercontent.com/44399944/235346282-8d45b078-fd03-414d-a078-d7346900dafb.png" alt="drawing" width="500"/>

 - C++
 
 Treesitter only:
  <img src="https://user-images.githubusercontent.com/44399944/235346959-b86c0028-f688-436a-ba5c-71837f9bfc2e.png" width="400"/>

 Current:
 <img src="https://user-images.githubusercontent.com/44399944/235346913-3530d001-3031-4734-8efb-bfdf1e84ce12.png" alt="drawing" width="400"/>
 
 Proposal:
  <img src="https://user-images.githubusercontent.com/44399944/235347002-177d9f1c-0f44-4da4-905c-6ffdc7f5ebff.png" alt="drawing" width="400"/>



