### PR TITLE
Add support for vim-illuminate plugin

### DIFF
--- a/lua/gruvbox/groups.lua
+++ b/lua/gruvbox/groups.lua
@@ -974,6 +974,10 @@ M.setup = function()
     NotifyWARNBorder = { link = "GruvboxYellow" },
     NotifyWARNIcon = { link = "GruvboxYellow" },
     NotifyWARNTitle = { link = "GruvboxYellow" },
+    -- vim-illuminate
+    IlluminatedWordText = { link = "LspReferenceText" },
+    IlluminatedWordRead = { link = "LspReferenceRead" },
+    IlluminatedWordWrite = { link = "LspReferenceWrite" },
 
     -- ts-rainbow2 (maintained fork)
     TSRainbowRed = { fg = colors.red },


### PR DESCRIPTION
Hey, thanks for your work !

This PR adds support for the vim-illuminate plugin.
Link to the repo: https://github.com/RRethy/vim-illuminate

----------------------

May I suggest using a highlighted background instead of changing the text color ? Of course it always comes down to preferences, and I have my own override, but I feel like most people will prefer the "traditional" way of highlighting, it feels weird in code:

![image](https://github.com/ellisonleao/gruvbox.nvim/assets/8455652/ed77bd55-1ff9-460c-a3b4-75313bee9623)

Maybe linking `LspReference*` to the `Visual` highlighting group would be more appropriate ?

![image](https://github.com/ellisonleao/gruvbox.nvim/assets/8455652/36e0da7d-19a2-4d66-8164-e77890ac0e86)

Granted, it's less colorful, but it's much more readable in my opinion