### PR TITLE
chore: expose get_groups function

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -210,7 +210,7 @@ local function get_colors()
   return color_groups[bg]
 end
 
-local function get_groups()
+Gruvbox.get_groups = function()
   local colors = get_colors()
   local config = Gruvbox.config
 
@@ -1071,7 +1071,7 @@ Gruvbox.load = function()
   vim.g.colors_name = "gruvbox"
   vim.o.termguicolors = true
 
-  local groups = get_groups()
+  local groups = Gruvbox.get_groups()
 
   -- add highlights
   for group, settings in pairs(groups) do


### PR DESCRIPTION
hey, I was using the `groups` module to [implement the `lightline` theme](https://github.com/perrin4869/dotfiles/blob/master/home/.config/nvim/autoload/lightline/colorscheme/gruvbox.vim), but I just noticed that the module was unified, and the groups are not publicly available anymore.
Would be extremely helpful if you could expose the function again