### PR TITLE
Removal of DapBreakpointSymbol and DapStoppedSymbol

### DIFF
--- a/doc/gruvbox.nvim.txt
+++ b/doc/gruvbox.nvim.txt
@@ -1,4 +1,4 @@
-*gruvbox.nvim.txt*       For Neovim >= 0.8.0      Last change: 2023 October 05
+*gruvbox.nvim.txt*       For Neovim >= 0.8.0      Last change: 2023 October 07
 
 ==============================================================================
 Table of Contents                             *gruvbox.nvim-table-of-contents*

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -909,8 +909,6 @@ local function get_groups()
     TSRainbowBlue = { fg = colors.blue },
     TSRainbowViolet = { fg = colors.purple },
     TSRainbowCyan = { fg = colors.cyan },
-    DapBreakpointSymbol = { fg = colors.red, bg = colors.bg1 },
-    DapStoppedSymbol = { fg = colors.green, bg = colors.bg1 },
     DapUIBreakpointsCurrentLine = { link = "GruvboxYellow" },
     DapUIBreakpointsDisabledLine = { link = "GruvboxGray" },
     DapUIBreakpointsInfo = { link = "GruvboxAqua" },


### PR DESCRIPTION
Based on changes done to the `added`, `modified` and `deleted` signs, `DapBreakpointSymbol` and `DapStoppedSymbol` needed some tweak as well since they weren't linking `GruvboxRed(Green)Sign` version of the color but the normal one that didn't address the transparent background. But thinking about it further, in reality those 2 highlight groups were added by me as custom HL groups to be able to represent the breakpoint with a symbol instead of plain text. As a consequence, those 2 hl groups weren't part of the `dap` nor `dap-ui` signature and therefore, they shouldn't belong to the colorscheme itself. The same goes to the existing `debugBreakpoint` and `debugPC` hl groups, which aren't part of the `dap` signature. So to keep things standarized, I think that these hl groups should be removed (or at least, the ones that were added by me in a previous PR which are `DapBreakpointSymbol` and `DapStoppedSymbol` that basically are used for the same purpose but probably by different users) and added by each of us if needed as shown in the provided screenshot.

`local colors = require('grubox').palette` moved to fit the screenshot for easier reference
![image](https://github.com/ellisonleao/gruvbox.nvim/assets/59997405/f2f6a982-137d-443f-a118-a95eaad093b4)

And this would be the custom result based on my given options.
![image](https://github.com/ellisonleao/gruvbox.nvim/assets/59997405/7433b496-fb25-4d10-8f1d-082570f7b125)

If this PR is not considered relevant, since all the hl groups mentioned aren't part of the `dap` signature, it should be specified in the `docs` that these hl groups exist and that could even be overriden as an option.

EDIT (latest changes):

Added `dap` signature hl groups `DapBreakpoint` and `DapStopped` to be used like this if needed:
![image](https://github.com/ellisonleao/gruvbox.nvim/assets/59997405/c46f0724-65fb-4b57-b921-831257e8cf03)

And the result would be:
![image](https://github.com/ellisonleao/gruvbox.nvim/assets/59997405/db1eccab-f44b-4a44-8727-c0d481775e94)

This would fit `dap` signature and serve as an starting point to tweak it further.