### PR TITLE
fix: could not see text under debugPC highlight

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -416,7 +416,7 @@ local function get_groups()
     NvimTreeGitNew = { fg = colors.neutral_yellow },
     NvimTreeGitDeleted = { fg = colors.neutral_red },
     NvimTreeWindowPicker = { bg = colors.aqua },
-    debugPC = { bg = colors.blue, fg = colors.bg0, reverse = config.reverse },
+    debugPC = { bg = colors.dark_green },
     debugBreakpoint = { link = "GruvboxRedSign" },
     StartifyBracket = { link = "GruvboxFg3" },
     StartifyFile = { link = "GruvboxFg1" },

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -416,7 +416,7 @@ local function get_groups()
     NvimTreeGitNew = { fg = colors.neutral_yellow },
     NvimTreeGitDeleted = { fg = colors.neutral_red },
     NvimTreeWindowPicker = { bg = colors.aqua },
-    debugPC = { bg = colors.blue },
+    debugPC = { bg = colors.blue, fg = colors.bg0, reverse = config.reverse },
     debugBreakpoint = { link = "GruvboxRedSign" },
     StartifyBracket = { link = "GruvboxFg3" },
     StartifyFile = { link = "GruvboxFg1" },


### PR DESCRIPTION
Close #288. This patch has been discussed in https://github.com/ellisonleao/gruvbox.nvim/pull/286#discussion_r1360699061. But I think that PR is for dap stuff.

This is the original
![image](https://github.com/ellisonleao/gruvbox.nvim/assets/58657914/56c3791c-7f6a-4021-ac45-4c66132645e2)

This is the fixed
![image](https://github.com/ellisonleao/gruvbox.nvim/assets/58657914/3a60b6e4-2d4c-47e7-af4f-cfd04e265d44)

Also, this is `reverse` turn on in gruvbox `setup`.
![image](https://github.com/ellisonleao/gruvbox.nvim/assets/58657914/b17e1b31-d444-4a5c-995a-a149e076895f)

Although we could not see the syntax highlight with lsp or treesitter after this change. I hope one day we could find a better color like #239. Also, thank you for your efforts in maintaining this project.