### PR TITLE
Add Light and Dark Variants

### DIFF
--- a/colors/gruvbox-dark.lua
+++ b/colors/gruvbox-dark.lua
@@ -1,0 +1,2 @@
+vim.o.background = "dark"
+require("gruvbox").load()

--- a/colors/gruvbox-light.lua
+++ b/colors/gruvbox-light.lua
@@ -1,0 +1,2 @@
+vim.o.background = "light"
+require("gruvbox").load()


### PR DESCRIPTION
I was messing around with Telescope's colorscheme switcher and found it really nice, but with how `gruvbox` is distributed currently, I could not find a nice way to directly switch to the light and dark variants (#297).

I'm not sure if this is best way to approach this problem (and I am very new to the neovim ecosystem, so forgive me if I missed something obvious) - but I found that this was a pretty straightforward method of implementing the schemes. Your thoughts?

Here's how it looks on my machine
<img width="1417" alt="Screenshot 2023-11-21 at 11 44 38 PM" src="https://github.com/ellisonleao/gruvbox.nvim/assets/84053270/6e40bc0e-3550-4be0-a8c5-bcc145852a88">

<img width="1402" alt="Screenshot 2023-11-21 at 11 50 36 PM" src="https://github.com/ellisonleao/gruvbox.nvim/assets/84053270/a3bb8de0-0875-449e-9d4e-3a32179206ba">
