### PR TITLE
chore: export 'get_groups'

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -210,7 +210,7 @@ local function get_colors()
   return color_groups[bg]
 end
 
-local function get_groups()
+function Gruvbox.get_groups()
   local colors = get_colors()
   local config = Gruvbox.config
 
@@ -1112,7 +1112,7 @@ Gruvbox.load = function()
   vim.g.colors_name = "gruvbox"
   vim.o.termguicolors = true
 
-  local groups = get_groups()
+  local groups = Gruvbox.get_groups()
 
   -- add highlights
   for group, settings in pairs(groups) do


### PR DESCRIPTION
exports the function `get_groups` for doing dump the highlight commands