### PR TITLE
Use generic color names from palette in overrides and other plugins setup code

### DIFF
--- a/doc/gruvbox.nvim.txt
+++ b/doc/gruvbox.nvim.txt
@@ -1,4 +1,4 @@
-*gruvbox.nvim.txt*       For Neovim >= 0.8.0      Last change: 2024 January 29
+*gruvbox.nvim.txt*      For Neovim >= 0.8.0      Last change: 2024 February 03
 
 ==============================================================================
 Table of Contents                             *gruvbox.nvim-table-of-contents*


### PR DESCRIPTION
I did couple of tries and came with this design. Now we can use 
```lua
    local colors = require('gruvbox').palette
    require("gruvbox").setup({
        contrast = "hard",
        overrides = {
            SignColumn = { bg = colors.bg0 },
            GruvboxRedSign = { bg = colors.bg0 },
```
as well as 
```lua
    local colors = require('gruvbox').palette
    require("bufferline").setup({
        highlights = {
            fill = {
                bg = colors.bg0,
            },
```
and `bg0` will be correct in both cases and for any `background`/`contrast` combinations we use.
#306 
