### PR TITLE
Fix path high-lighting to not look like URL

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -959,7 +959,7 @@ local function get_groups()
     ["@string.regexp"] = { link = "String" },
     ["@string.escape"] = { link = "SpecialChar" },
     ["@string.special"] = { link = "SpecialChar" },
-    ["@string.special.path"] = { link = "Underlined" },
+    ["@string.special.path"] = { link = "GruvboxOrange" },
     ["@string.special.symbol"] = { link = "Identifier" },
     ["@string.special.url"] = { link = "Underlined" },
     ["@character"] = { link = "Character" },


### PR DESCRIPTION
My relevant use-case is for Nix paths, which used to be linked to `GruvboxOrange`, and just look wrong when underlined.