### PR TITLE
fix(python): import semantic_token highlights from basedpyright

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -1003,7 +1003,7 @@ local function get_groups()
     ["@attribute"] = { link = "PreProc" },
     ["@field"] = { link = "Identifier" },
     ["@property"] = { link = "Identifier" },
-    ["@variable"] = { link = "GruvboxFg1" },
+    ["@variable"] = {}, -- defer to treesitter for regular variables
     ["@variable.builtin"] = { link = "Special" },
     ["@variable.member"] = { link = "Identifier" },
     ["@variable.parameter"] = { link = "Identifier" },
@@ -1079,6 +1079,8 @@ local function get_groups()
     ["@lsp.type.type"] = { link = "@type" },
     ["@lsp.type.typeParameter"] = { link = "@type.definition" },
     ["@lsp.type.variable"] = { link = "@variable" },
+    --python
+    ["@lsp.type.namespace.python"] = { link = "@variable" },
   }
 
   for group, hl in pairs(config.overrides) do

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -1003,7 +1003,7 @@ local function get_groups()
     ["@attribute"] = { link = "PreProc" },
     ["@field"] = { link = "Identifier" },
     ["@property"] = { link = "Identifier" },
-    ["@variable"] = {}, -- defer to treesitter for regular variables
+    ["@variable"] = { link = "GruvboxFg1" },
     ["@variable.builtin"] = { link = "Special" },
     ["@variable.member"] = { link = "Identifier" },
     ["@variable.parameter"] = { link = "Identifier" },
@@ -1078,7 +1078,7 @@ local function get_groups()
     ["@lsp.type.struct"] = { link = "@type" },
     ["@lsp.type.type"] = { link = "@type" },
     ["@lsp.type.typeParameter"] = { link = "@type.definition" },
-    ["@lsp.type.variable"] = { link = "@variable" },
+    ["@lsp.type.variable"] = {}, -- defer to treesitter for regular variables
     --python
     ["@lsp.type.namespace.python"] = { link = "@variable" },
   }


### PR DESCRIPTION
Basedpyright is a relatively new python LSP that is a fork of the popular and commonly used pyright lsp. However, pyright lsp does not have semantic tokens as a feature. Several color schemes have begun to make alterations to their codebase in the last day or so to accommodate this change because as of right now the tokens are breaking the highlights when enabled. 

Proposed fix requires ~ 2 lines of code change, and the first person I saw make this change was Folke with this [Tokyonight commit.](https://github.com/folke/tokyonight.nvim/commit/2983390e0ee59a40c02bb90df9bad860f251534a)