### PR TITLE
Allow `overrides` to be `function(colors)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,27 @@ require("gruvbox").setup({
 vim.cmd("colorscheme gruvbox")
 ```
 
+`overrides` can also be a `function(colors)` which returns table of overriden groups
+
+```lua
+require("gruvbox").setup({
+    overrides = function(colors)
+        return {
+            Title = { link = "GruvboxYellowBold" },
+            ["@comment"] = { fg = colors.gray, italic = true, bold = false },
+        }
+    end
+})
+vim.cmd("colorscheme gruvbox")
+```
+
+`colors` has those fields:
+  * `bg0`, `bg1`, `bg2`, `bg3`, `bg4`,
+  * `fg0`, `fg1`, `fg2`, `fg3`, `fg4`,
+  * `red`, `green`, `yellow`, `blue`, `purple`, `aqua`, `orange`, `gray`,
+  * `neutral_red`, `neutral_green`, `neutral_yellow`, `neutral_blue`, `neutral_purple`, `neutral_aqua`,
+  * `dark_red`, `dark_green`, `dark_aqua`.
+
 Please note that the override values must follow the attributes from the highlight group map, such as:
 
 - **fg** - foreground color

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -41,7 +41,7 @@ local Gruvbox = {}
 ---@field invert_tabline boolean?
 ---@field invert_intend_guides boolean?
 ---@field inverse boolean?
----@field overrides table<string, HighlightDefinition>?
+---@field overrides [table<string, HighlightDefinition> | fun(colors: table<string, string>): table<string, HighlightDefinition>]
 ---@field palette_overrides table<string, string>?
 Gruvbox.config = {
   terminal_colors = true,
@@ -1205,7 +1205,16 @@ local function get_groups()
     ["@lsp.type.variable"] = { link = "@variable" },
   }
 
-  for group, hl in pairs(config.overrides) do
+  local overrides = {}
+  if config.overrides ~= nil then
+    if type(config.overrides) == "table" then
+      overrides = config.overrides
+    elseif type(config.overrides) == "function" then
+      overrides = config.overrides(colors)
+    end
+  end
+
+  for group, hl in pairs(overrides) do
     if groups[group] then
       -- "link" should not mix with other configs (:h hi-link)
       groups[group].link = nil


### PR DESCRIPTION
This patch checks for table and function in `config.overrides` and extracts overriden groups appropriate way. Also README.md is updated to reflect this change.