### PR TITLE
Enabling to work with a 256 color terminal 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ require("gruvbox").setup({
   overrides = {},
   dim_inactive = false,
   transparent_mode = false,
+  truecolor = true, -- enable vim.o.termguicolor. If false, adapt to support 256 color terminals
 })
 vim.cmd("colorscheme gruvbox")
 ```
@@ -97,10 +98,13 @@ You can specify your own palette colors. For example:
 require("gruvbox").setup({
     palette_overrides = {
         bright_green = "#990000",
+        white = { gui = "#ffffff", cterm=255 }
     }
 })
 vim.cmd("colorscheme gruvbox")
 ```
+Note that the color can be specified as hex if truecolor=true, otherwise, use the form `{ gui = #RRGGBB, cterm=30 }` which allows to 
+specify a cterm color index. 
 
 ### Highlight groups
 
@@ -134,5 +138,14 @@ Please note that the override values must follow the attributes from the highlig
 - **bg** - background color
 - **bold** - true or false for bold font
 - **italic** - true or false for italic font
+- ctermfg - cterm color index foreground (for 256 color terminals)
+- ctermbg - cterm color index background (for 256 color terminals)
 
 Other values can be seen in [`synIDattr`](<https://neovim.io/doc/user/builtin.html#synIDattr()>)
+
+
+### 256 color terminals 
+
+Disable the truecolor flag and the plugin will select similar colors from the 256 color palette. 
+Make sure to set the cterm index if overrides are made. 
+

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -71,60 +71,59 @@ Gruvbox.config = {
 -- main gruvbox color palette
 ---@class GruvboxPalette
 Gruvbox.palette = {
-  dark0_hard = "#1d2021",
-  dark0 = "#282828",
-  dark0_soft = "#32302f",
-  dark1 = "#3c3836",
-  dark2 = "#504945",
-  dark3 = "#665c54",
-  dark4 = "#7c6f64",
-  light0_hard = "#f9f5d7",
-  light0 = "#fbf1c7",
-  light0_soft = "#f2e5bc",
-  light1 = "#ebdbb2",
-  light2 = "#d5c4a1",
-  light3 = "#bdae93",
-  light4 = "#a89984",
-  bright_red = "#fb4934",
-  bright_green = "#b8bb26",
-  bright_yellow = "#fabd2f",
-  bright_blue = "#83a598",
-  bright_purple = "#d3869b",
-  bright_aqua = "#8ec07c",
-  bright_orange = "#fe8019",
-  neutral_red = "#cc241d",
-  neutral_green = "#98971a",
-  neutral_yellow = "#d79921",
-  neutral_blue = "#458588",
-  neutral_purple = "#b16286",
-  neutral_aqua = "#689d6a",
-  neutral_orange = "#d65d0e",
-  faded_red = "#9d0006",
-  faded_green = "#79740e",
-  faded_yellow = "#b57614",
-  faded_blue = "#076678",
-  faded_purple = "#8f3f71",
-  faded_aqua = "#427b58",
-  faded_orange = "#af3a03",
-  dark_red_hard = "#792329",
-  dark_red = "#722529",
-  dark_red_soft = "#7b2c2f",
-  light_red_hard = "#fc9690",
-  light_red = "#fc9487",
-  light_red_soft = "#f78b7f",
-  dark_green_hard = "#5a633a",
-  dark_green = "#62693e",
-  dark_green_soft = "#686d43",
-  light_green_hard = "#d3d6a5",
-  light_green = "#d5d39b",
-  light_green_soft = "#cecb94",
-  dark_aqua_hard = "#3e4934",
-  dark_aqua = "#49503b",
-  dark_aqua_soft = "#525742",
-  light_aqua_hard = "#e6e9c1",
-  light_aqua = "#e8e5b5",
-  light_aqua_soft = "#e1dbac",
-  gray = "#928374",
+ dark0 = { ["gui"] = "#282828", ["cterm"] = 235 },
+ dark0_soft = { ["gui"] = "#32302f", ["cterm"] = 236 },
+ dark1 = { ["gui"] = "#3c3836", ["cterm"] = 237 },
+ dark2 = { ["gui"] = "#504945", ["cterm"] = 239 },
+ dark3 = { ["gui"] = "#665c54", ["cterm"] = 59 },
+ dark4 = { ["gui"] = "#7c6f64", ["cterm"] = 242 },
+ light0_hard = { ["gui"] = "#f9f5d7", ["cterm"] = 230 },
+ light0 = { ["gui"] = "#fbf1c7", ["cterm"] = 230 },
+ light0_soft = { ["gui"] = "#f2e5bc", ["cterm"] = 223 },
+ light1 = { ["gui"] = "#ebdbb2", ["cterm"] = 187 },
+ light2 = { ["gui"] = "#d5c4a1", ["cterm"] = 187 },
+ light3 = { ["gui"] = "#bdae93", ["cterm"] = 144 },
+ light4 = { ["gui"] = "#a89984", ["cterm"] = 138 },
+ bright_red = { ["gui"] = "#fb4934", ["cterm"] = 203 },
+ bright_green = { ["gui"] = "#b8bb26", ["cterm"] = 142 },
+ bright_yellow = { ["gui"] = "#fabd2f", ["cterm"] = 214 },
+ bright_blue = { ["gui"] = "#83a598", ["cterm"] = 108 },
+ bright_purple = { ["gui"] = "#d3869b", ["cterm"] = 174 },
+ bright_aqua = { ["gui"] = "#8ec07c", ["cterm"] = 108 },
+ bright_orange = { ["gui"] = "#fe8019", ["cterm"] = 208 },
+ neutral_red = { ["gui"] = "#cc241d", ["cterm"] = 160 },
+ neutral_green = { ["gui"] = "#98971a", ["cterm"] = 100 },
+ neutral_yellow = { ["gui"] = "#d79921", ["cterm"] = 172 },
+ neutral_blue = { ["gui"] = "#458588", ["cterm"] = 66 },
+ neutral_purple = { ["gui"] = "#b16286", ["cterm"] = 132 },
+ neutral_aqua = { ["gui"] = "#689d6a", ["cterm"] = 71 },
+ neutral_orange = { ["gui"] = "#d65d0e", ["cterm"] = 166 },
+ faded_red = { ["gui"] = "#9d0006", ["cterm"] = 124 },
+ faded_green = { ["gui"] = "#79740e", ["cterm"] = 100 },
+ faded_yellow = { ["gui"] = "#b57614", ["cterm"] = 136 },
+ faded_blue = { ["gui"] = "#076678", ["cterm"] = 24 },
+ faded_purple = { ["gui"] = "#8f3f71", ["cterm"] = 95 },
+ faded_aqua = { ["gui"] = "#427b58", ["cterm"] = 65 },
+ faded_orange = { ["gui"] = "#af3a03", ["cterm"] = 130 },
+ dark_red_hard = { ["gui"] = "#792329", ["cterm"] = 88 },
+ dark_red = { ["gui"] = "#722529", ["cterm"] = 237 },
+ dark_red_soft = { ["gui"] = "#7b2c2f", ["cterm"] = 238 },
+ light_red_hard = { ["gui"] = "#fc9690", ["cterm"] = 210 },
+ light_red = { ["gui"] = "#fc9487", ["cterm"] = 210 },
+ light_red_soft = { ["gui"] = "#f78b7f", ["cterm"] = 210 },
+ dark_green_hard = { ["gui"] = "#5a633a", ["cterm"] = 240 },
+ dark_green = { ["gui"] = "#62693e", ["cterm"] = 240 },
+ dark_green_soft = { ["gui"] = "#686d43", ["cterm"] = 59 },
+ light_green_hard = { ["gui"] = "#d3d6a5", ["cterm"] = 187 },
+ light_green = { ["gui"] = "#d5d39b", ["cterm"] = 186 },
+ light_green_soft = { ["gui"] = "#cecb94", ["cterm"] = 186 },
+ dark_aqua_hard = { ["gui"] = "#3e4934", ["cterm"] = 238 },
+ dark_aqua = { ["gui"] = "#49503b", ["cterm"] = 238 },
+ dark_aqua_soft = { ["gui"] = "#525742", ["cterm"] = 239 },
+ light_aqua_hard = { ["gui"] = "#e6e9c1", ["cterm"] = 187 },
+ light_aqua = { ["gui"] = "#e8e5b5", ["cterm"] = 187 },
+ light_aqua_soft = { ["gui"] = "#e1dbac", ["cterm"] = 187 },
+ gray = { ["gui"] = "#928374", ["cterm"] = 244 }
 }
 
 -- get a hex list of gruvbox colors based on current bg and constrast config
@@ -210,6 +209,42 @@ local function get_colors()
   return color_groups[bg]
 end
 
+-- apply gui and cterm colors to the highlight groups given as an argument. 
+-- function works in-place, thus hl_groups will be altered
+local function expand_colors_in_highlights(hl_groups)
+  -- iterate over highlights
+  for k,hl in pairs(hl_groups) do
+    -- check if foreground value is set and expand and replace 
+    if hl.fg ~= nil then
+      if hl.fg == "NONE" then 
+        hl.ctermfg = "NONE"
+        hl.fg = "NONE"
+      else
+        hl.ctermfg = hl.fg.cterm
+        hl.fg = hl.fg.gui
+      end
+    end
+    -- check if background value is set and expand and replace 
+    if hl.bg ~= nil then
+      if hl.bg == "NONE" then 
+        hl.ctermbg = "NONE"
+        hl.bg = "NONE"
+      else
+        hl.ctermbg = hl.bg.cterm
+        hl.bg = hl.bg.gui
+      end
+    end
+    -- check if background value is set and expand and replace 
+    if hl.sp ~= nil then
+      if hl.sp == "NONE" then 
+        hl.sp = "NONE"
+      else
+        hl.sp = hl.sp.gui
+      end
+    end
+  end
+end
+  
 local function get_groups()
   local colors = get_colors()
   local config = Gruvbox.config
@@ -1219,6 +1254,8 @@ local function get_groups()
     groups[group] = vim.tbl_extend("force", groups[group] or {}, hl)
   end
 
+  expand_colors_in_highlights(groups)
+
   return groups
 end
 
@@ -1239,7 +1276,6 @@ Gruvbox.load = function()
     vim.cmd.hi("clear")
   end
   vim.g.colors_name = "gruvbox"
-  vim.o.termguicolors = true
 
   local groups = get_groups()
 

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -213,35 +213,28 @@ end
 -- apply gui and cterm colors to the highlight groups given as an argument.
 -- function works in-place, thus hl_groups will be altered
 local function expand_colors_in_highlights(hl_groups)
+  local function expand_highlight_prop(hl, prop)
+    if hl[prop] == nil then
+      return
+    end
+    if hl[prop] == "NONE" then
+      if prop ~= "sp" then
+        hl["cterm" .. prop] = "NONE"
+      end
+      hl[prop] = "NONE"
+    else
+      if prop ~= "sp" then
+        hl["cterm" .. prop] = hl[prop].cterm
+      end
+      hl[prop] = hl[prop].gui
+    end
+  end
+
   -- iterate over highlights
-  for k, hl in pairs(hl_groups) do
-    -- check if foreground value is set and expand and replace
-    if hl.fg ~= nil then
-      if hl.fg == "NONE" then
-        hl.ctermfg = "NONE"
-        hl.fg = "NONE"
-      else
-        hl.ctermfg = hl.fg.cterm
-        hl.fg = hl.fg.gui
-      end
-    end
-    -- check if background value is set and expand and replace
-    if hl.bg ~= nil then
-      if hl.bg == "NONE" then
-        hl.ctermbg = "NONE"
-        hl.bg = "NONE"
-      else
-        hl.ctermbg = hl.bg.cterm
-        hl.bg = hl.bg.gui
-      end
-    end
-    -- check if background value is set and expand and replace
-    if hl.sp ~= nil then
-      if hl.sp == "NONE" then
-        hl.sp = "NONE"
-      else
-        hl.sp = hl.sp.gui
-      end
+  for _, hl in pairs(hl_groups) do
+    -- check if cterm values are set, expand and replace
+    for _, prop in pairs({ "fg", "bg", "sp" }) do
+      expand_highlight_prop(hl, prop)
     end
   end
 end

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -71,59 +71,60 @@ Gruvbox.config = {
 -- main gruvbox color palette
 ---@class GruvboxPalette
 Gruvbox.palette = {
- dark0 = { ["gui"] = "#282828", ["cterm"] = 235 },
- dark0_soft = { ["gui"] = "#32302f", ["cterm"] = 236 },
- dark1 = { ["gui"] = "#3c3836", ["cterm"] = 237 },
- dark2 = { ["gui"] = "#504945", ["cterm"] = 239 },
- dark3 = { ["gui"] = "#665c54", ["cterm"] = 59 },
- dark4 = { ["gui"] = "#7c6f64", ["cterm"] = 242 },
- light0_hard = { ["gui"] = "#f9f5d7", ["cterm"] = 230 },
- light0 = { ["gui"] = "#fbf1c7", ["cterm"] = 230 },
- light0_soft = { ["gui"] = "#f2e5bc", ["cterm"] = 223 },
- light1 = { ["gui"] = "#ebdbb2", ["cterm"] = 187 },
- light2 = { ["gui"] = "#d5c4a1", ["cterm"] = 187 },
- light3 = { ["gui"] = "#bdae93", ["cterm"] = 144 },
- light4 = { ["gui"] = "#a89984", ["cterm"] = 138 },
- bright_red = { ["gui"] = "#fb4934", ["cterm"] = 203 },
- bright_green = { ["gui"] = "#b8bb26", ["cterm"] = 142 },
- bright_yellow = { ["gui"] = "#fabd2f", ["cterm"] = 214 },
- bright_blue = { ["gui"] = "#83a598", ["cterm"] = 108 },
- bright_purple = { ["gui"] = "#d3869b", ["cterm"] = 174 },
- bright_aqua = { ["gui"] = "#8ec07c", ["cterm"] = 108 },
- bright_orange = { ["gui"] = "#fe8019", ["cterm"] = 208 },
- neutral_red = { ["gui"] = "#cc241d", ["cterm"] = 160 },
- neutral_green = { ["gui"] = "#98971a", ["cterm"] = 100 },
- neutral_yellow = { ["gui"] = "#d79921", ["cterm"] = 172 },
- neutral_blue = { ["gui"] = "#458588", ["cterm"] = 66 },
- neutral_purple = { ["gui"] = "#b16286", ["cterm"] = 132 },
- neutral_aqua = { ["gui"] = "#689d6a", ["cterm"] = 71 },
- neutral_orange = { ["gui"] = "#d65d0e", ["cterm"] = 166 },
- faded_red = { ["gui"] = "#9d0006", ["cterm"] = 124 },
- faded_green = { ["gui"] = "#79740e", ["cterm"] = 100 },
- faded_yellow = { ["gui"] = "#b57614", ["cterm"] = 136 },
- faded_blue = { ["gui"] = "#076678", ["cterm"] = 24 },
- faded_purple = { ["gui"] = "#8f3f71", ["cterm"] = 95 },
- faded_aqua = { ["gui"] = "#427b58", ["cterm"] = 65 },
- faded_orange = { ["gui"] = "#af3a03", ["cterm"] = 130 },
- dark_red_hard = { ["gui"] = "#792329", ["cterm"] = 88 },
- dark_red = { ["gui"] = "#722529", ["cterm"] = 237 },
- dark_red_soft = { ["gui"] = "#7b2c2f", ["cterm"] = 238 },
- light_red_hard = { ["gui"] = "#fc9690", ["cterm"] = 210 },
- light_red = { ["gui"] = "#fc9487", ["cterm"] = 210 },
- light_red_soft = { ["gui"] = "#f78b7f", ["cterm"] = 210 },
- dark_green_hard = { ["gui"] = "#5a633a", ["cterm"] = 240 },
- dark_green = { ["gui"] = "#62693e", ["cterm"] = 240 },
- dark_green_soft = { ["gui"] = "#686d43", ["cterm"] = 59 },
- light_green_hard = { ["gui"] = "#d3d6a5", ["cterm"] = 187 },
- light_green = { ["gui"] = "#d5d39b", ["cterm"] = 186 },
- light_green_soft = { ["gui"] = "#cecb94", ["cterm"] = 186 },
- dark_aqua_hard = { ["gui"] = "#3e4934", ["cterm"] = 238 },
- dark_aqua = { ["gui"] = "#49503b", ["cterm"] = 238 },
- dark_aqua_soft = { ["gui"] = "#525742", ["cterm"] = 239 },
- light_aqua_hard = { ["gui"] = "#e6e9c1", ["cterm"] = 187 },
- light_aqua = { ["gui"] = "#e8e5b5", ["cterm"] = 187 },
- light_aqua_soft = { ["gui"] = "#e1dbac", ["cterm"] = 187 },
- gray = { ["gui"] = "#928374", ["cterm"] = 244 }
+  dark0_hard = { gui = "#1d2021", cterm = 234 },
+  dark0 = { gui = "#282828", cterm = 235 },
+  dark0_soft = { gui = "#32302f", cterm = 236 },
+  dark1 = { gui = "#3c3836", cterm = 237 },
+  dark2 = { gui = "#504945", cterm = 239 },
+  dark3 = { gui = "#665c54", cterm = 59 },
+  dark4 = { gui = "#7c6f64", cterm = 242 },
+  light0_hard = { gui = "#f9f5d7", cterm = 230 },
+  light0 = { gui = "#fbf1c7", cterm = 230 },
+  light0_soft = { gui = "#f2e5bc", cterm = 223 },
+  light1 = { gui = "#ebdbb2", cterm = 187 },
+  light2 = { gui = "#d5c4a1", cterm = 187 },
+  light3 = { gui = "#bdae93", cterm = 144 },
+  light4 = { gui = "#a89984", cterm = 138 },
+  bright_red = { gui = "#fb4934", cterm = 203 },
+  bright_green = { gui = "#b8bb26", cterm = 142 },
+  bright_yellow = { gui = "#fabd2f", cterm = 214 },
+  bright_blue = { gui = "#83a598", cterm = 108 },
+  bright_purple = { gui = "#d3869b", cterm = 174 },
+  bright_aqua = { gui = "#8ec07c", cterm = 108 },
+  bright_orange = { gui = "#fe8019", cterm = 208 },
+  neutral_red = { gui = "#cc241d", cterm = 160 },
+  neutral_green = { gui = "#98971a", cterm = 100 },
+  neutral_yellow = { gui = "#d79921", cterm = 172 },
+  neutral_blue = { gui = "#458588", cterm = 66 },
+  neutral_purple = { gui = "#b16286", cterm = 132 },
+  neutral_aqua = { gui = "#689d6a", cterm = 71 },
+  neutral_orange = { gui = "#d65d0e", cterm = 166 },
+  faded_red = { gui = "#9d0006", cterm = 124 },
+  faded_green = { gui = "#79740e", cterm = 100 },
+  faded_yellow = { gui = "#b57614", cterm = 136 },
+  faded_blue = { gui = "#076678", cterm = 24 },
+  faded_purple = { gui = "#8f3f71", cterm = 95 },
+  faded_aqua = { gui = "#427b58", cterm = 65 },
+  faded_orange = { gui = "#af3a03", cterm = 130 },
+  dark_red_hard = { gui = "#792329", cterm = 88 },
+  dark_red = { gui = "#722529", cterm = 237 },
+  dark_red_soft = { gui = "#7b2c2f", cterm = 238 },
+  light_red_hard = { gui = "#fc9690", cterm = 210 },
+  light_red = { gui = "#fc9487", cterm = 210 },
+  light_red_soft = { gui = "#f78b7f", cterm = 210 },
+  dark_green_hard = { gui = "#5a633a", cterm = 240 },
+  dark_green = { gui = "#62693e", cterm = 240 },
+  dark_green_soft = { gui = "#686d43", cterm = 59 },
+  light_green_hard = { gui = "#d3d6a5", cterm = 187 },
+  light_green = { gui = "#d5d39b", cterm = 186 },
+  light_green_soft = { gui = "#cecb94", cterm = 186 },
+  dark_aqua_hard = { gui = "#3e4934", cterm = 238 },
+  dark_aqua = { gui = "#49503b", cterm = 238 },
+  dark_aqua_soft = { gui = "#525742", cterm = 239 },
+  light_aqua_hard = { gui = "#e6e9c1", cterm = 187 },
+  light_aqua = { gui = "#e8e5b5", cterm = 187 },
+  light_aqua_soft = { gui = "#e1dbac", cterm = 187 },
+  gray = { gui = "#928374", cterm = 244 },
 }
 
 -- get a hex list of gruvbox colors based on current bg and constrast config
@@ -209,14 +210,14 @@ local function get_colors()
   return color_groups[bg]
 end
 
--- apply gui and cterm colors to the highlight groups given as an argument. 
+-- apply gui and cterm colors to the highlight groups given as an argument.
 -- function works in-place, thus hl_groups will be altered
 local function expand_colors_in_highlights(hl_groups)
   -- iterate over highlights
-  for k,hl in pairs(hl_groups) do
-    -- check if foreground value is set and expand and replace 
+  for k, hl in pairs(hl_groups) do
+    -- check if foreground value is set and expand and replace
     if hl.fg ~= nil then
-      if hl.fg == "NONE" then 
+      if hl.fg == "NONE" then
         hl.ctermfg = "NONE"
         hl.fg = "NONE"
       else
@@ -224,9 +225,9 @@ local function expand_colors_in_highlights(hl_groups)
         hl.fg = hl.fg.gui
       end
     end
-    -- check if background value is set and expand and replace 
+    -- check if background value is set and expand and replace
     if hl.bg ~= nil then
-      if hl.bg == "NONE" then 
+      if hl.bg == "NONE" then
         hl.ctermbg = "NONE"
         hl.bg = "NONE"
       else
@@ -234,9 +235,9 @@ local function expand_colors_in_highlights(hl_groups)
         hl.bg = hl.bg.gui
       end
     end
-    -- check if background value is set and expand and replace 
+    -- check if background value is set and expand and replace
     if hl.sp ~= nil then
-      if hl.sp == "NONE" then 
+      if hl.sp == "NONE" then
         hl.sp = "NONE"
       else
         hl.sp = hl.sp.gui
@@ -244,7 +245,7 @@ local function expand_colors_in_highlights(hl_groups)
     end
   end
 end
-  
+
 local function get_groups()
   local colors = get_colors()
   local config = Gruvbox.config

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -249,7 +249,8 @@ local function get_groups()
   local colors = get_colors()
   local config = Gruvbox.config
 
-  if config.terminal_colors then
+  -- setting terminal colors is only supported for RGB
+  if config.terminal_colors and vim.o.termguicolors then
     local term_colors = {
       colors.bg0,
       colors.neutral_red,
@@ -269,7 +270,7 @@ local function get_groups()
       colors.fg1,
     }
     for index, value in ipairs(term_colors) do
-      vim.g["terminal_color_" .. index - 1] = value
+      vim.g["terminal_color_" .. index - 1] = value.gui
     end
   end
 

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -43,7 +43,7 @@ local Gruvbox = {}
 ---@field inverse boolean?
 ---@field overrides table<string, HighlightDefinition>?
 ---@field palette_overrides table<string, string>?
----@field enable_256_colors boolean?
+---@field truecolor boolean?
 Gruvbox.config = {
   terminal_colors = true,
   undercurl = true,
@@ -134,8 +134,13 @@ local function get_colors()
   local p = Gruvbox.palette
   local config = Gruvbox.config
 
-  for color, hex in pairs(config.palette_overrides) do
-    p[color] = hex
+  for color, value in pairs(config.palette_overrides) do
+    if type(value) == "table" then
+      p[color] = value
+    else
+      p[color] = { gui = value }
+    end
+    print(p[color])
   end
 
   local bg = vim.o.background
@@ -1274,11 +1279,7 @@ Gruvbox.load = function()
   end
   vim.g.colors_name = "gruvbox"
 
-  if Gruvbox.config.enable_256_colors then
-    vim.o.termguicolors = false
-  else
-    vim.o.termguicolors = true
-  end
+  vim.o.termguicolors = Gruvbox.config.truecolor
 
   local groups = get_groups()
 

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -43,6 +43,7 @@ local Gruvbox = {}
 ---@field inverse boolean?
 ---@field overrides table<string, HighlightDefinition>?
 ---@field palette_overrides table<string, string>?
+---@field enable_256_colors boolean?
 Gruvbox.config = {
   terminal_colors = true,
   undercurl = true,
@@ -66,6 +67,7 @@ Gruvbox.config = {
   overrides = {},
   dim_inactive = false,
   transparent_mode = false,
+  enable_256_colors = false,
 }
 
 -- main gruvbox color palette
@@ -1271,6 +1273,12 @@ Gruvbox.load = function()
     vim.cmd.hi("clear")
   end
   vim.g.colors_name = "gruvbox"
+
+  if Gruvbox.config.enable_256_colors then
+    vim.o.termguicolors = false
+  else
+    vim.o.termguicolors = true
+  end
 
   local groups = get_groups()
 


### PR DESCRIPTION
### Summary
This pull-request enables the gruvbox plugin to display close colors also on a 256 color terminal. This is e.g. the case for the Terminal that is part of MacOS which does not support RGB/24Bit color/termguicolors. The only thing that the user needs to do is ensure that termguicolors is set to false on a 256 color terminal. 

### Use case
Users that cannot or don't want to change their terminal application that only supports 256 colors to a terminal that supports 24Bit colors but still would like to enjoy the gruvbox color scheme. So far, the colorscheme is not usable on terminals that support and this change would make it much easier for users that are in that situation to make use of the plugin. 

### Implementation
Similar cterm indexes are selected to match the 24bit colors as close as possible for all colors of the palette (this was automatically done with a python script, which can be supplied if desired). The palette is then extended with these indexes. At the end, the palette entries are expanded prior to the call to the vim api. 

### Side effect of the proposed changes
To work in a 256 color terminal, termguicolors needs to be false. ~~Since it is currently forced to true in the plugin code, this is removed (Line 1242). Termguicolors thus now needs to be set outside of the plugin eg. in the plugin configuration.~~ To minimize side effects a configuration option is proposed. 

### Screenshots
Screenshot showing colors on a 256 color terminal prior to change (left iTerm2 with 24bit color, right Terminal 256 colors):
<img width="1196" alt="Screenshot showing colors on a 256 color terminal prior to change" src="https://github.com/user-attachments/assets/11492b24-4a6d-44a6-9bf0-488228694ebd">

After change: Comparison of colors 24bit enabled (left on iTerm with vim.o.termguicolors=true) and 256 colors (right Mac default Terminal with vim.o.termguicolors=false). 
<img width="1196" alt="Color comparison 24Bit vs. 256 colors" src="https://github.com/user-attachments/assets/278f2465-6377-4cc5-a8a7-5574df8c051a">

### Final remarks
@ellisonleao, let me know what you think and whether there would be changes needed before this could be merged. 

I'm looking forward to your and others feedback! 