### PR TITLE
Add @lsp.type.modifier.java

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -1201,6 +1201,7 @@ local function get_groups()
     ["@lsp.type.interface"] = { link = "@constructor" },
     ["@lsp.type.macro"] = { link = "@macro" },
     ["@lsp.type.method"] = { link = "@method" },
+    ["@lsp.type.modifier.java"] = { link = "@keyword.type.java" },
     ["@lsp.type.namespace"] = { link = "@namespace" },
     ["@lsp.type.parameter"] = { link = "@parameter" },
     ["@lsp.type.property"] = { link = "@property" },


### PR DESCRIPTION
Without LSP semantic highlight:

![2024-11-23_12-27](https://github.com/user-attachments/assets/a71d4bd9-309f-424b-93bf-c3fa5f9a326e)

With LSP semantic highlight (jdtls):

![2024-11-23_12-28](https://github.com/user-attachments/assets/21e2be5b-ae7f-47d4-b433-166dd2d63580)

This PR defines a highlight for java modifiers linking to the appropriate treesitter highlight shown in the first screenshot.