### PR TITLE
Fix overrides not resetting fg or bg

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -1213,8 +1213,7 @@ local function get_groups()
 
   for group, hl in pairs(config.overrides) do
     if groups[group] then
-      -- "link" should not mix with other configs (:h hi-link)
-      groups[group].link = nil
+      groups[group] = nil
     end
 
     groups[group] = vim.tbl_extend("force", groups[group] or {}, hl)


### PR DESCRIPTION
The problem is when the group already has its own fg and bg, like DiffText. I want to override the bg color (see #314) but still retain the fg color, which is the syntax color provided by treesitter or LSP.

```lua
require("gruvbox").setup({
    overrides = {
        DiffText = {bg = "#6f5a2b"}
    }
})
vim.cmd("colorscheme gruvbox")
```

The
[DiffText](https://github.com/ellisonleao/gruvbox.nvim/blob/main/lua/gruvbox.lua#L366) has the fg color `bg0` and overrides doesn't clear fg color for me. So I can't get the syntax color provided by treesitter and LSP.