### PR TITLE
Missing CocSearch highlight

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -466,6 +466,7 @@ local function get_groups()
     CocDiagnosticsWarning = { link = "GruvboxOrange" },
     CocDiagnosticsInfo = { link = "GruvboxBlue" },
     CocDiagnosticsHint = { link = "GruvboxAqua" },
+    CocSearch = { link = "GruvboxBlue" },
     CocSelectedText = { link = "GruvboxRed" },
     CocMenuSel = { link = "PmenuSel" },
     CocCodeLens = { link = "GruvboxGray" },


### PR DESCRIPTION
Added a highlight group that was missing:
before:
![image](https://github.com/user-attachments/assets/7a1ac5ad-70ee-458b-9408-de66094ca943)
after:
![image](https://github.com/user-attachments/assets/c3a60421-d978-4b24-9ceb-6fd3d4c12e6c)
