### PR TITLE
Link `LspReferenceTarget` to `Visual`

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -393,6 +393,7 @@ local function get_groups()
     DiagnosticVirtualTextHint = { link = "GruvboxAqua" },
     DiagnosticOk = { link = "GruvboxGreenSign" },
     LspReferenceRead = { link = "GruvboxYellowBold" },
+    LspReferenceTarget = { link = "Visual" },
     LspReferenceText = { link = "GruvboxYellowBold" },
     LspReferenceWrite = { link = "GruvboxOrangeBold" },
     LspCodeLens = { link = "GruvboxGray" },


### PR DESCRIPTION
Closes #392 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new highlight style for LSP reference targets, improving visual distinction when navigating code references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->