### PR TITLE
lua/gruvbox: remove unused option

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -39,7 +39,6 @@ local Gruvbox = {}
 ---@field invert_selection boolean?
 ---@field invert_signs boolean?
 ---@field invert_tabline boolean?
----@field invert_intend_guides boolean?
 ---@field inverse boolean?
 ---@field overrides table<string, HighlightDefinition>?
 ---@field palette_overrides table<string, string>?
@@ -59,7 +58,6 @@ Gruvbox.config = {
   invert_selection = false,
   invert_signs = false,
   invert_tabline = false,
-  invert_intend_guides = false,
   inverse = true,
   contrast = "",
   palette_overrides = {},


### PR DESCRIPTION
Except I have one doubt about this config: why is it not used anywhere in the code? Was the use lost when you refactored the plugin?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the configuration option for indent guides, ensuring consistent naming and improved clarity in settings.
	- Removed the obsolete indent guide inversion setting from the configuration for a cleaner user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->