### PR TITLE
Remove `invert_intend_guides` references

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ require("gruvbox").setup({
   invert_selection = false,
   invert_signs = false,
   invert_tabline = false,
-  invert_intend_guides = false,
   inverse = true, -- invert background for search, diffs, statuslines and errors
   contrast = "", -- can be "hard", "soft" or empty string
   palette_overrides = {},

--- a/doc/gruvbox.nvim.txt
+++ b/doc/gruvbox.nvim.txt
@@ -95,7 +95,6 @@ Additional settings for gruvbox are:
       invert_selection = false,
       invert_signs = false,
       invert_tabline = false,
-      invert_intend_guides = false,
       inverse = true, -- invert background for search, diffs, statuslines and errors
       contrast = "", -- can be "hard", "soft" or empty string
       palette_overrides = {},

--- a/tests/gruvbox/gruvbox_spec.lua
+++ b/tests/gruvbox/gruvbox_spec.lua
@@ -32,7 +32,6 @@ describe("tests", function()
       invert_selection = false,
       invert_signs = false,
       invert_tabline = false,
-      invert_intend_guides = false,
       contrast = "",
       palette_overrides = {},
       overrides = {},


### PR DESCRIPTION
Continuation of #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Removed the `invert_intend_guides` option from the README and help documentation.
  - Updated example configurations to reflect this change.

- **Tests**
  - Modified test cases to exclude the `invert_intend_guides` option from configuration validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->