### PR TITLE
Indicate `dim_inactive` and `transparent_mode` as optional

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -35,13 +35,13 @@ local Gruvbox = {}
 ---@field bold boolean?
 ---@field italic ItalicConfig?
 ---@field strikethrough boolean?
----@field contrast Contrast?
 ---@field invert_selection boolean?
 ---@field invert_signs boolean?
 ---@field invert_tabline boolean?
 ---@field inverse boolean?
----@field overrides table<string, HighlightDefinition>?
+---@field contrast Contrast?
 ---@field palette_overrides table<string, string>?
+---@field overrides table<string, HighlightDefinition>?
 ---@field dim_inactive boolean?
 ---@field transparent_mode boolean?
 Gruvbox.config = {

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -42,6 +42,8 @@ local Gruvbox = {}
 ---@field inverse boolean?
 ---@field overrides table<string, HighlightDefinition>?
 ---@field palette_overrides table<string, string>?
+---@field dim_inactive boolean?
+---@field transparent_mode boolean?
 Gruvbox.config = {
   terminal_colors = true,
   undercurl = true,

--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -29,21 +29,21 @@ local Gruvbox = {}
 ---@field nocombine boolean?
 
 ---@class GruvboxConfig
----@field terminal_colors boolean?
----@field undercurl boolean?
----@field underline boolean?
 ---@field bold boolean?
----@field italic ItalicConfig?
----@field strikethrough boolean?
+---@field contrast Contrast?
+---@field dim_inactive boolean?
+---@field inverse boolean?
 ---@field invert_selection boolean?
 ---@field invert_signs boolean?
 ---@field invert_tabline boolean?
----@field inverse boolean?
----@field contrast Contrast?
----@field palette_overrides table<string, string>?
+---@field italic ItalicConfig?
 ---@field overrides table<string, HighlightDefinition>?
----@field dim_inactive boolean?
+---@field palette_overrides table<string, string>?
+---@field strikethrough boolean?
+---@field terminal_colors boolean?
 ---@field transparent_mode boolean?
+---@field undercurl boolean?
+---@field underline boolean?
 Gruvbox.config = {
   terminal_colors = true,
   undercurl = true,


### PR DESCRIPTION
Small fix to type annotations so that LSP doesn't complain about missing `dim_inactive` and `transparent_mode` fields. Took the opportunity to also re-sort the field annotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new configuration options: "dim_inactive", "inverse", and "transparent_mode" for enhanced customization.
  - Enabled "contrast" and "overrides" settings in the configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->