### PR TITLE
Make multiple calls to setup() independent

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -44,7 +44,7 @@ local Gruvbox = {}
 ---@field transparent_mode boolean?
 ---@field undercurl boolean?
 ---@field underline boolean?
-Gruvbox.config = {
+local default_config = {
   terminal_colors = true,
   undercurl = true,
   underline = true,
@@ -67,6 +67,8 @@ Gruvbox.config = {
   dim_inactive = false,
   transparent_mode = false,
 }
+
+Gruvbox.config = vim.deepcopy(default_config)
 
 -- main gruvbox color palette
 ---@class GruvboxPalette
@@ -1311,6 +1313,7 @@ end
 
 ---@param config GruvboxConfig?
 Gruvbox.setup = function(config)
+  Gruvbox.config = vim.deepcopy(default_config)
   Gruvbox.config = vim.tbl_deep_extend("force", Gruvbox.config, config or {})
 end
 

--- a/tests/gruvbox/gruvbox_spec.lua
+++ b/tests/gruvbox/gruvbox_spec.lua
@@ -157,4 +157,33 @@ describe("tests", function()
     vim.opt.background = "light"
     assert.are.same(vim.g.terminal_color_0, colors.light0)
   end)
+
+  it("multiple calls to setup() are independent", function()
+    -- First call to setup
+    gruvbox.setup({
+      contrast = "soft",
+      overrides = { CursorLine = { bg = "#FF0000" } },
+    })
+    assert.are.same(gruvbox.config.contrast, "soft")
+    assert.are.same(gruvbox.config.overrides.CursorLine.bg, "#FF0000")
+
+    -- Second call to setup
+    gruvbox.setup({ contrast = "hard" })
+    assert.are.same(gruvbox.config.contrast, "hard")
+    -- Check that overrides from the first call are not present
+    assert.is_nil(gruvbox.config.overrides.CursorLine)
+
+    -- Third call to setup with different overrides
+    gruvbox.setup({
+      overrides = { Normal = { fg = "#00FF00" } },
+    })
+    assert.are.same(gruvbox.config.contrast, "") -- Contrast should be reset to default (empty string)
+    assert.is_nil(gruvbox.config.overrides.CursorLine) -- Still no CursorLine override
+    assert.are.same(gruvbox.config.overrides.Normal.fg, "#00FF00") -- New override is present
+
+    -- Call setup with no arguments to reset to defaults
+    gruvbox.setup()
+    assert.are.same(gruvbox.config.contrast, "")
+    assert.is_nil(gruvbox.config.overrides.Normal)
+  end)
 end)


### PR DESCRIPTION
Previously, multiple calls to `gruvbox.setup()` would merge configurations, leading to unexpected behavior when trying to reset or change specific settings like `overrides` or `contrast`.

This commit addresses the issue by ensuring that each call to `setup()` starts with a fresh copy of the default configuration before applying the user-provided settings.

This change makes calls to `setup()` idempotent and independent of previous calls, as suggested in issue #402.

A new test case has been added to verify this behavior.

Resolves #402