### PR TITLE
fix: DiagnosticDeprecated follows strikethrough setting

### DIFF
--- a/lua/gruvbox.lua
+++ b/lua/gruvbox.lua
@@ -376,6 +376,7 @@ local function get_groups()
     DiagnosticError = { link = "GruvboxRed" },
     DiagnosticWarn = { link = "GruvboxYellow" },
     DiagnosticInfo = { link = "GruvboxBlue" },
+    DiagnosticDeprecated = { strikethrough = config.strikethrough },
     DiagnosticHint = { link = "GruvboxAqua" },
     DiagnosticOk = { link = "GruvboxGreen" },
     DiagnosticSignError = { link = "GruvboxRedSign" },


### PR DESCRIPTION
Maybe a color should be assigned to this highlight group? This clears this group if someone disables strikethrough.