### PR TITLE
fix: vim.pack.add missing a repo source

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Neovim 0.8.0+
 
 ```lua
 vim.pack.add({
-  "ellisonleao/gruvbox.nvim"
+  "https://github.com/ellisonleao/gruvbox.nvim"
 })
 
 require("gruvbox").setup()

--- a/doc/gruvbox.nvim.txt
+++ b/doc/gruvbox.nvim.txt
@@ -39,7 +39,7 @@ USING VIM.PACK (NEOVIM 0.12+)*gruvbox.nvim-installing-using-vim.pack-(neovim-0.1
 
 >lua
     vim.pack.add({
-      "ellisonleao/gruvbox.nvim"
+      "https://github.com/ellisonleao/gruvbox.nvim"
     })
     
     require("gruvbox").setup()


### PR DESCRIPTION
## Problem
```lua
vim.pack.add({
  "ellisonleao/gruvbox.nvim"
})
```
throws `fatal: repository 'ellisonleao/gruvbox.nvim' does not exist` when starting nvim.

## Solution
Adding `https://github.com/` in front of `ellisonleao/gruvbox.nvim` fixes the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated Neovim installation examples to use the explicit GitHub repository URL format instead of shorthand notation, improving clarity for users following setup instructions across all documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->